### PR TITLE
完成单个管理员模块的CRUD，填满了很多坑（基本上都是前后交互入参出参的问题）。

### DIFF
--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/ProductCategoryController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/ProductCategoryController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.product.ProductCategoryRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.product.bean.ProductCategory;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 产品模块 - 分类
  */
 @Controller
 @RequestMapping("/productCategory")
 public class ProductCategoryController extends BaseControllerImpl<ProductCategory, ProductCategoryRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return true;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/ProductController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/ProductController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.product.ProductRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.product.bean.Product;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 产品模块 - 产品操作
  */
 @Controller
 @RequestMapping("/product")
 public class ProductController extends BaseControllerImpl<Product, ProductRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/ProductImageController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/ProductImageController.java
@@ -4,11 +4,26 @@ import me.cathub.change.api.rpc.server.product.ProductImageRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.product.bean.ProductImage;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 产品模块 - 产品图片
  */
 @Controller
 @RequestMapping("/productImage")
 public class ProductImageController extends BaseControllerImpl<ProductImage, ProductImageRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return true;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
+
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/ProductReviewController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/ProductReviewController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.product.ProductReviewRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.product.bean.ProductReview;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 产品模块 - 评论
  */
 @Controller
 @RequestMapping("/productReview")
 public class ProductReviewController extends BaseControllerImpl<ProductReview, ProductReviewRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/PropertyController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/PropertyController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.product.PropertyRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.product.bean.Property;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 产品模块 - 属性
  */
 @Controller
 @RequestMapping("/property")
 public class PropertyController extends BaseControllerImpl<Property, PropertyRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/PropertyValueRpcController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/product/PropertyValueRpcController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.product.PropertyValueRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.product.bean.PropertyValue;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 产品模块 - 属性值
  */
 @Controller
 @RequestMapping("/propertyValue")
 public class PropertyValueRpcController extends BaseControllerImpl<PropertyValue, PropertyValueRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/upms/PermissionController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/upms/PermissionController.java
@@ -4,7 +4,10 @@ import me.cathub.change.api.rpc.server.upms.PermissionRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.upms.bean.Permission;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
 
 /**
  * 权限模块 - 权限操作
@@ -13,4 +16,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/permission")
 public class PermissionController extends BaseControllerImpl<Permission, PermissionRpcServer> {
 
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/upms/RoleController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/upms/RoleController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.upms.RoleRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.upms.bean.Role;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 权限模块 - 角色操作
  */
 @Controller
 @RequestMapping("/role")
 public class RoleController extends BaseControllerImpl<Role, RoleRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/AdminController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/AdminController.java
@@ -2,17 +2,15 @@ package me.cathub.change.admin.brandquotient.web.controller.user;
 
 import me.cathub.change.api.rpc.server.user.AdminRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
-import me.cathub.change.common.base.PageResult;
 import me.cathub.change.user.bean.Admin;
-import me.cathub.change.user.bean.User;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.util.*;
+import java.util.Map;
 
 /**
  * 用户模块下的管理crud
@@ -21,94 +19,39 @@ import java.util.*;
 @RequestMapping("/admin")
 public class AdminController extends BaseControllerImpl<Admin, AdminRpcServer>{
 
-    //模拟数据
-    static List<User> aaa = new ArrayList();
-    static{
-        User user = new User();
-        user.setId(12313);
-        user.setPassword("1231");
-        user.setUsername("lisa");
-        user.setPhone("12345678977");
-        user.setStatus(1);
-        user.setEmail("104564@1231.com");
-        User user2 = new User();
-        user2.setId(456789);
-        user2.setCreateDate(new Date());
-        user2.setUpdateDate(new Date());
-        user2.setPassword("1231");
-        user2.setUsername("lisa");
-        user2.setPhone("12345678977");
-        user2.setEmail("104564@1231.com");
-        aaa.add(user);
-        aaa.add(user2);
-    }
-
-
-    //测试与前台交互
-    @RequestMapping("/inserts")
-    @ResponseBody
-    public boolean inserts(Admin bean) throws Exception {
-        System.out.println(bean);
-        bean.setId(3);
-        aaa.add(bean);
-        return true;
-    }
-
-    //测试与前台交互
-    @RequestMapping("/lists")
-    @ResponseBody
-    public Object lists(Integer page, Integer count, Integer tableIndex, String searchText, HttpServletRequest request,
-                        HttpServletResponse response) throws Exception {
-        System.out.println(page + "," + count + "," + tableIndex);
-
-        /**
-         * 自己封装的数据返回类型，bootstrap-table要求服务器返回的json数据必须包含：total，rows（即实际数据）两个节点
-         * bootstrap-table根据服务器端返回的total，以及table设定的pageSize，自动生成分页的页面元素，每次点击下一页或者指定页码，
-         * bootstrap-table会自动给参数pageNumber赋值，服务器返回指定页的数据。
-         */
-        Map map = new HashMap();
-        map.put("rows", aaa);
-        map.put("total", 100);
-        return new PageResult(aaa,100);
-    }
-
-    //测试与前台交互
-    @RequestMapping("/updates")
-    @ResponseBody
-    public boolean update(Admin bean) throws Exception {
-        System.out.println("【update:->】"+bean);
-        User temp = null;
-        for (User admin : aaa) {
-            if(admin.getId() == bean.getId()){
-                temp = admin;
-            }
-        }
-        aaa.remove(temp);
-        aaa.add(bean);
-        return true;
-    }
-
-    //测试删除
+    /**
+     * 删除/批量删除
+     * @param ids 前台传入的数组对象，注意：这里要用long[] 接受 ，id太长了int[]接会报错。
+     * @throws Exception
+     */
     @RequestMapping("/delete")
     @ResponseBody
-    public boolean deleteL(@RequestParam(value = "ids[]") Integer[] ids){
-        System.out.println(ids.toString());
-        List<Integer> delList = new ArrayList();
-        if(ids.length != 0){
-            for(int i = 0; i < ids.length ; i++){
-                for (int j = 0; j < aaa.size(); j++) {
-                    if(aaa.get(j).getId() == ids[i]){
-                        delList.add(j);
-                    }
-                }
-            }
+    public boolean delete(@RequestParam("ids[]") long[] ids) throws Exception {
+        boolean flag = true;
+        for (long id : ids) {
+            Admin admin = new Admin();
+            admin.setId(id);
+            admin = getRpcService().select(admin,true);
+            flag = getRpcService().deleteL(admin);//逻辑删除
         }
-        for (Integer j : delList) {
-            aaa.remove(aaa.get(j));
-        }
-        return true;
+        return flag;
     }
 
+    @Override
+    public void update_modelAttribute(@RequestParam(value = "id",required = false)Long id, Map<String, Object> map) throws Exception {
+        if(id!=null) {
+            Admin admin = new Admin();
+            admin.setId(id);
+            admin = select(admin);
+            map.put("admin", admin);
+        }
+    }
 
+    @RequestMapping("/update")
+    @ResponseBody
+    public boolean update(@ModelAttribute("admin") Admin bean) throws Exception {
+        System.out.println(bean);
+        return getRpcService().update(bean);
+    }
 
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/AuditingController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/AuditingController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.user.AuditingRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.user.bean.Auditing;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 用户模块下的审核crud
  */
 @Controller
 @RequestMapping("/auditing")
 public class AuditingController extends BaseControllerImpl<Auditing, AuditingRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return true;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/BrandQuotientController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/BrandQuotientController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.user.BrandQuotientRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.user.bean.BrandQuotient;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 用户模块下的品牌商crud
  */
 @Controller
 @RequestMapping("/brandQuotient")
 public class BrandQuotientController extends BaseControllerImpl<BrandQuotient, BrandQuotientRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/CompanyController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/CompanyController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.user.CompanyRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.user.bean.Company;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 用户模块下的企业crud
  */
 @Controller
 @RequestMapping("/company")
 public class CompanyController extends BaseControllerImpl<Company, CompanyRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/OnlineStoreController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/OnlineStoreController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.user.OnlineStoreRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.user.bean.OnlineStore;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 用户模块下的网店crud
  */
 @Controller
 @RequestMapping("/onlineStore")
 public class OnlineStoreController extends BaseControllerImpl<OnlineStore, OnlineStoreRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/ShopkeeperController.java
+++ b/change-admin/src/main/java/me/cathub/change/admin/brandquotient/web/controller/user/ShopkeeperController.java
@@ -4,11 +4,25 @@ import me.cathub.change.api.rpc.server.user.ShopkeeperRpcServer;
 import me.cathub.change.common.base.BaseControllerImpl;
 import me.cathub.change.user.bean.Shopkeeper;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
 /**
  * 用户模块下的店主crud
  */
 @Controller
 @RequestMapping("/shopkeeper")
 public class ShopkeeperController extends BaseControllerImpl<Shopkeeper, ShopkeeperRpcServer> {
+    @Override
+    public boolean delete(long[] ids) throws Exception {
+
+        return false;
+    }
+
+    @Override
+    public void update_modelAttribute(Long id, Map<String, Object> map) throws Exception {
+
+    }
 }

--- a/change-admin/src/main/resources/log4j.properties
+++ b/change-admin/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 # 配置根Logger
-log4j.rootLogger=warn,stdout  
+log4j.rootLogger=debug,stdout  
 
 # 输出到控制台
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender  

--- a/change-admin/web/view/crud/admin_crud.html
+++ b/change-admin/web/view/crud/admin_crud.html
@@ -40,6 +40,10 @@
             <input id="create-password" type="text" class="form-control" name="password">
         </div>
         <div class="form-group">
+            <label for="create-name">真实姓名</label>
+            <input id="create-name" type="text" class="form-control" name="name">
+        </div>
+        <div class="form-group">
             <label for="create-phone">手机号</label>
             <input id="create-phone" type="text" class="form-control" name="phone">
         </div>
@@ -62,6 +66,10 @@
             <input id="update-password" type="text" class="form-control update-password" name="password">
         </div>
         <div class="form-group">
+            <label for="update-name">真实姓名</label>
+            <input id="update-name" type="text" class="form-control update-name" name="name">
+        </div>
+        <div class="form-group">
             <label for="update-phone">手机号</label>
             <input id="update-phone" type="text" class="form-control update-phone" name="phone">
         </div>
@@ -71,7 +79,7 @@
         </div>
         <div class="form-group">
             <label for="update-status">状态</label>
-            <input id="update-status" type="" class="form-control update-status" name="status">
+            <input id="update-status" type="nubmer" class="form-control update-status" name="status" value="1">
         </div>
     </form>
 </div>
@@ -110,6 +118,7 @@
             minimumCountColumns: 2,
             showPaginationSwitch: true,
             clickToSelect: true,
+            cache: false, // 不使用缓存
             detailView: true,
             detailFormatter: 'detailFormatter',
             pagination: true,
@@ -120,7 +129,7 @@
             //设置为limit可以获取limit, offset, search, sort, order
             queryParamsType: "undefined",
             pageNumber: 1, // 页码，点击上下页自动更改值
-            pageSize: 20,  // 页大小，点击大小自动更改值
+            pageSize: 15,  // 页大小，点击大小自动更改值
             smartDisplay: false,
             //silentSort: false,
             idField: 'id',
@@ -141,9 +150,10 @@
             },
             columns: [
                 {field: 'state', checkbox: true},
-                {field: 'id', title: '编号', sortable: true, halign: 'left'},
+                {field: 'id', title: '编号', sortable: false, halign: 'left'},
                 {field: 'username', title: '账户', sortable: true, halign: 'left'},
                 {field: 'password', title: '密码', sortable: true, halign: 'left'},
+                {field: 'name', title: '真实姓名', sortable: true, halign: 'left'},
                 {field: 'phone', title: '电话', sortable: true, halign: 'left'},
                 {field: 'email', title: '邮箱', sortable: true, halign: 'left'},
                 {field: 'role.name', title: '角色', sortable: true, halign: 'left'},
@@ -222,7 +232,7 @@
                     btnClass: 'waves-effect waves-button',
                     action: function () {
                         $.ajax({
-                            url: "../../admin/inserts",
+                            url: "../../admin/insert",
                             type: "POST",
                             contentType: "application/x-www-form-urlencoded",
                             dataType: "json",
@@ -243,6 +253,7 @@
 
     // 编辑 id:用户编号
     function updateAction(id) {
+        console.log("编辑的id-> " + id);
         $.confirm({
             type: 'blue',
             animationSpeed: 300,
@@ -253,18 +264,37 @@
                     text: '确认',
                     btnClass: 'waves-effect waves-button',
                     action: function () {
+                        var username = $(".update-username:last").val();
+                        var password = $(".update-password:last").val();
+                        var name = $(".update-name:last").val();
+                        var phone = $(".update-phone:last").val();
+                        var email = $(".update-email:last").val();
+                        var status = $(".update-status:last").val();
+
+                        //创建json对象
+                        var json = {};
+                        json.id = id;
+                        json.up_id = id;
+                        if (password != '') {
+                            json.password = password;
+                        }
+                        if (name != '') {
+                            json.name = name;
+                        }
+                        if (phone != '') {
+                            json.phone = phone;
+                        }
+                        if (email != '') {
+                            json.email = email;
+                        }
+                        if (status != '') {
+                            json.status = status;
+                        }
                         $.ajax({
-                            url: "../../admin/updates",
+                            url: "../../admin/update",
                             type: "POST",
                             dataType: "json",
-                            data: {
-                                "id": id,
-                                "username": $(".update-username:last").val(),
-                                "password": $(".update-password:last").val(),
-                                "phone": $(".update-phone:last").val(),
-                                "email": $(".update-email:last").val(),
-                                "status": $(".update-status:last").val()
-                            },
+                            data: json,
                             success: function () {
                                 $table.bootstrapTable('refresh');
                             }
@@ -279,10 +309,9 @@
         });
     }
 
-    // 删除
+    // 删除 多个删除不会传入id，单个删除会传入id。
     function deleteAction(id) {
-        var rows = $table.bootstrapTable('getSelections');
-        // debugger;
+        var rows = $table.bootstrapTable('getSelections');//多个删除id自己获取，如果用户选中了多个，但是点击的单个文件的删除此时id会有值，并且会进行多个删除，用户会骂人的。在下面需要加入判断！
         if (rows.length == 0 && id == null) {
             $.confirm({
                 title: false,
@@ -307,23 +336,25 @@
                         text: '确认',
                         btnClass: 'waves-effect waves-button',
                         action: function () {
+                            //不管批量删除还是单个删除都用数组保存传递到后台。后台对应一个方法。
                             var ids = new Array();
-                            if (rows.length != 0) { //如果是多个删除
+                            //rows长度不为0，说明选中了多个，想要批量删除？呵~天真，我就要选择多个但是点击单个删除咋地？你不能给我批量删除。
+                            if (rows.length != 0 && id == null) {
                                 for (var i in rows) {
                                     ids.push(rows[i].id);
                                 }
-                            }else {
-                                ids.push(id);   //如果是单个删除
+                            } else { // 是点击右边的单个删除会传id过来
+                                ids.push(id);   //单个删除
                             }
-                            // $.alert('删除：id=' + ids);
+                            console.log('删除：id=' + ids);
                             //异步删除
                             $.ajax({
                                 url: "../../admin/delete",
-                                type: "POST",
+                                type: "post",
                                 dataType: "json",
-                                data: {ids:ids},
+                                data: {ids: ids},
                                 success: function () {
-                                    $table.bootstrapTable('refresh');
+                                    $('#table').bootstrapTable('refresh');
                                 }
                             });
                         }

--- a/change-admin/web/view/crud/company_crud.html
+++ b/change-admin/web/view/crud/company_crud.html
@@ -19,7 +19,7 @@
 <div id="main">
 	<div id="toolbar">
 		<a class="waves-effect waves-button" href="javascript:;" onclick="createAction()"><i class="zmdi zmdi-plus"></i> 新增企业</a>
-		<a class="waves-effect waves-button" href="javascript:;" onclick="updateAction()"><i class="zmdi zmdi-edit"></i> 编辑企业</a>
+		<!--<a class="waves-effect waves-button" href="javascript:;" onclick="updateAction()"><i class="zmdi zmdi-edit"></i> 编辑企业</a>-->
 		<a class="waves-effect waves-button" href="javascript:;" onclick="deleteAction()"><i class="zmdi zmdi-close"></i> 删除企业</a>
 	</div>
 	<table id="table"></table>

--- a/change-admin/项目笔记.txt
+++ b/change-admin/项目笔记.txt
@@ -1,0 +1,58 @@
+#1：SpringMVC是可以接收数组类型的，前台通过json传入一个数组对象：data:{"ids":ids} ，后台入参 public void delete(@RequestParam("ids[]") long[] ids)
+       注意后台的参数名要与前台的一致，一个细节：由于id过长，后台不能用int类型接收，需要使用long类型（user类的id本身也是long类型的。）
+
+#2：json数据已经传到了前台，但是id与后台查出的id不一致！通过观察浏览器控制台看出 response和preview两个选项中的json数据不一致，response中是后台
+       原原本本传过来的数据，而preview中的json数据是浏览器把json字符串解析成json对象后展示给页面的显示数据，id不一致就是在preview的时候出问题的。
+      ##原因：后台传过来的id由于数值过大（long类型）在js解析成json对象时出现了“精度丢失”，解决办法是后台传数据过来之前把 long 类型转成 String 类型
+      ##解决方案：1. 新建一个继承JsonSerializer<T>的类(LongJsonSerializer)，泛型里是原来的数据类型，实现父类的抽象方法在方法里转成 String类型
+                            2.实体类的属性或geetter方法上添加 @JsonSerialize(using = LongJsonSerializer.class) 注解
+                            反序列化也是如此，继承的是JsonDeserializer。
+
+#3：* 项目依赖问题：由于该项目存在多个Moudle，有些Moudle之间存在依赖关系，需要在 Moudel Structure中添加模块依赖
+       * 存在某个配置文件但是加载上下文时死活报没有找到异常，很有可能是没有把该配置文件所在的文件夹设置为“资源文件夹”。
+
+#4：前台页面做删除的时候，因为使用的是 bootstrap table 在异步删除之后的success方法中刷新表格$('#table').bootstrapTable('refresh');无效，
+       ##原因是后台需要设置布尔值返回true才会调用success中的代码，否则不能删除。
+
+#5：前端编辑时，状态必须传数值，否则后台报错，需要添加校验！【记住】
+
+#6：执行更新操作时的一个坑，大坑！实际上是 ModelAttribute 注解的一个注意点。
+        #如何导致的#  用户点击更新按钮弹出更新窗口的表单项，由于表单值不回显，所以用户看到的是一个空的编辑表单项，但无关紧要。我们需要实现的
+        是只更新用户填写的那一项，但是！其他空白的没有填写的值不代表更新成空串！而是不更新这些字段！如果不使用 ModelAttribute 注解修饰的方法在修改操作前
+        初始化用户信息就执行修改的话用户没有填写的值全部更新没了，没了，只留下表单填写中更新的那一条数据。
+        #栗子#：编辑表单只填写了需要修改的邮箱地址，id放入了隐藏域，其他没有填写，执行调用更新方法先进入 ModelAttribute 修饰的方法根据id取到了完整用户数据
+        并且key匹配正确，然后进入目标方法（更新方法）却死活没有把初始化好的对象赋值到入参中，仅仅是前台传过来的值。
+        #原因#
+        一通排查之后发现：如果前台有对应的表单项（name与后台对象属性相同）但是没有填写值，传入到后台对象的时候值是空串，注意，空串！如果前台没有对应的表单项
+        传入到后台对象的时候值是null！
+       SpringMVC 把 ModelAttribute 中初始化好的对象赋值给目标方法的入参的时候，如果入参的属性是 null 才会注入对应的值，如果是 "" 不会注入值，这也是为什么自以为
+       ModelAttribute 注解失效的原因。
+       #解决办法#
+       js中，通过判断用户输入的表单是不是空串，即是否输入，如果是空串，不创建json对象的属性，如果不是空串，创建json对象对应的表单属性值。
+                        //创建json对象，注意： name = null 传入到后台还是 '' !
+                        var json = {};
+                        json.id = id;
+                        json.up_id = id;
+                        if (password != '') {
+                            json.password = password;
+                        }
+                        if (name != '') {
+                            json.name = name;
+                        }
+                        if (phone != '') {
+                            json.phone = phone;
+                        }
+                        if (email != '') {
+                            json.email = email;
+                        }
+                        if (status != '') {
+                            json.status = status;
+                        }
+	                    ......
+	                    $.ajax({
+                            ......
+                            data: json,
+                            success: function () {
+                                $table.bootstrapTable('refresh');
+                            }
+                        });

--- a/change-common/change-common-base/src/main/java/me/cathub/change/common/base/BaseControllerImpl.java
+++ b/change-common/change-common-base/src/main/java/me/cathub/change/common/base/BaseControllerImpl.java
@@ -1,67 +1,76 @@
 package me.cathub.change.common.base;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 public abstract class BaseControllerImpl<B extends Serializable, S extends BaseRpcServer> implements BaseDao<B> {
 
     @Autowired
     S rpcService;
 
+    public S getRpcService() {
+        return rpcService;
+    }
+
+    //抽象方法，删除/批量删除都在同一个方法，入参是long[],需要查询每个控制器对应的实体信息。
+    public abstract boolean delete(long[] ids) throws Exception;
+
     @RequestMapping("/insert")
     @ResponseBody
     @Override
     public boolean insert(B bean) throws Exception {
-//        return rpcService.insert(bean) != -1 ? true : false;
-        return true;
+        return rpcService.insert(bean) != -1 ? true : false;
     }
+
 
     @RequestMapping("/deleteL")
     @ResponseBody
     @Override
     public boolean deleteL(B bean) throws Exception {
-//        return rpcService.deleteL(bean);
-        return true;
+        return rpcService.deleteL(bean);
     }
 
     @RequestMapping("/restore")
     @ResponseBody
     @Override
     public boolean restore(B bean) throws Exception {
-//        return rpcService.restore(bean);
-        return true;
+        return rpcService.restore(bean);
     }
 
     @RequestMapping("/deleteP")
     @ResponseBody
     @Override
     public boolean deleteP(B bean) throws Exception {
-//        return rpcService.deleteP(bean);
-        return true;
+        return rpcService.deleteP(bean);
     }
+
+
+    @ModelAttribute
+    public abstract void update_modelAttribute(@RequestParam(value = "id",required = false)Long id, Map<String, Object> map) throws Exception;
 
     @RequestMapping("/update")
     @ResponseBody
     @Override
     public boolean update(B bean) throws Exception {
-//        return rpcService.update(bean);
-        return true;
+        System.out.println(bean);
+        return rpcService.update(bean);
     }
 
     @RequestMapping("/select")
     @ResponseBody
     @Override
     public B select(B bean) throws Exception {
-//        return (B) rpcService.select(bean);
-        return null;
+        return (B) rpcService.select(bean, true);
     }
 
-//    @RequestMapping("/list")
-//    @ResponseBody
     @Override
     public List<B> list(int page, int count, int tableIndex) throws Exception {
         return rpcService.list(page, count, tableIndex, false); // flag:是否关联查询（true：不关联）
@@ -72,23 +81,21 @@ public abstract class BaseControllerImpl<B extends Serializable, S extends BaseR
     @Override
     public int count(int tableIndex) throws Exception {
         return rpcService.count(tableIndex);
-//        return 0;
     }
 
     @RequestMapping("/list")
     @ResponseBody
     public PageResult list1(int page, int count, int tableIndex) throws Exception {
-        List rows = list(page,count,tableIndex);
+        List rows = list(page, count, tableIndex);
         int total = count(tableIndex);
-        return new PageResult(rows,total);
+        return new PageResult(rows, total);
     }
 
     @RequestMapping("/clear")
     @ResponseBody
     @Override
     public int clear(int tableIndex) throws Exception {
-//        return rpcService.clear(tableIndex);
-        return 0;
+        return rpcService.clear(tableIndex);
     }
 
 

--- a/change-common/change-common-tool/src/main/java/me/cathub/change/common/tool/LongJsonDeserializer.java
+++ b/change-common/change-common-tool/src/main/java/me/cathub/change/common/tool/LongJsonDeserializer.java
@@ -1,0 +1,31 @@
+package me.cathub.change.common.tool;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: z.yu
+ * DateTime: 2018-05-01 10:38
+ * Description: 前端传输到后端，反序列化时，再重新转换为Long类型。
+ */
+public class LongJsonDeserializer extends JsonDeserializer<Long> {
+    private static final Logger logger = LoggerFactory.getLogger(LongJsonDeserializer.class);
+
+    @Override
+    public Long deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+        String value = jsonParser.getText();
+        try {
+            return value == null ? null : Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            logger.error("解析长整形错误", e);
+            return null;
+        }
+    }
+}

--- a/change-common/change-common-tool/src/main/java/me/cathub/change/common/tool/LongJsonSerializer.java
+++ b/change-common/change-common-tool/src/main/java/me/cathub/change/common/tool/LongJsonSerializer.java
@@ -1,0 +1,24 @@
+package me.cathub.change.common.tool;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: z.yu
+ * DateTime: 2018-05-01 1:16
+ * Description: 后端传前端 Long 类型字段序列化为 json 时转为字符串类型，避免js丢失精度
+ */
+public class LongJsonSerializer extends JsonSerializer<Long> {
+    @Override
+    public void serialize(Long value, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+        String text = (value == null ? null : String.valueOf(value));
+        if (text != null) {
+            jsonGenerator.writeString(text);
+        }
+    }
+}

--- a/change-user/change-user-bean/pom.xml
+++ b/change-user/change-user-bean/pom.xml
@@ -26,5 +26,10 @@
             <artifactId>jackson-annotations</artifactId>
             <version>RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>RELEASE</version>
+        </dependency>
     </dependencies>
 </project>

--- a/change-user/change-user-bean/src/main/java/me/cathub/change/user/bean/User.java
+++ b/change-user/change-user-bean/src/main/java/me/cathub/change/user/bean/User.java
@@ -1,6 +1,8 @@
 package me.cathub.change.user.bean;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import me.cathub.change.common.tool.LongJsonSerializer;
 import me.cathub.change.upms.bean.Role;
 
 import java.io.Serializable;
@@ -10,6 +12,7 @@ import java.util.Date;
  * 用户
  */
 public class User implements Serializable {
+    @JsonSerialize(using = LongJsonSerializer.class) //作用在属性或getter上，用于在序列化json时嵌入自己的代码。比如long转成String
     protected long id;
     protected String username;
     protected String password;
@@ -105,7 +108,7 @@ public class User implements Serializable {
         this.password = password;
     }
 
-    @JsonFormat(pattern="yyyy-MM-dd hh:mm:ss",timezone = "GMT+8")
+    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss",timezone = "GMT+8")
     public Date getCreateDate() {
         return createDate;
     }
@@ -114,7 +117,7 @@ public class User implements Serializable {
         this.createDate = createDate;
     }
 
-    @JsonFormat(pattern="yyyy-MM-dd hh:mm:ss",timezone = "GMT+8")
+    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss",timezone = "GMT+8")
     public Date getUpdateDate() {
         return updateDate;
     }


### PR DESCRIPTION
1.解决了列表展示时 json源数据和页面json对象渲染long类型id精度丢失的问题。
2.解决了新增操作时 id 过长，报参数错误异常。
3.批量/单个删除的代码优化。解决了删除操作时，异步删除之后的success方法中刷新表格$('#table').bootstrapTable('refresh');无效的问题。
4.解决了更新操作时，未填写字段清空问题。解决了使用 @ModelAttribute 注解时，目标入参注入失败的问题。